### PR TITLE
Add retry mechanism to mount and network downloads

### DIFF
--- a/host/storage.go
+++ b/host/storage.go
@@ -37,20 +37,20 @@ const (
 )
 
 func MountBootPartition() error {
-	return mountPartitionRetry(BootPartitionLabel, BootPartitionFSType, BootPartitionMountPoint, 60, 8, 1)
+	return mountPartitionRetry(BootPartitionLabel, BootPartitionFSType, BootPartitionMountPoint, 8, 1)
 }
 
 func MountDataPartition() error {
-	return mountPartitionRetry(DataPartitionLabel, DataPartitionFSType, DataPartitionMountPoint, 60, 8, 1)
+	return mountPartitionRetry(DataPartitionLabel, DataPartitionFSType, DataPartitionMountPoint, 8, 1)
 }
 
-func mountPartitionRetry(label, fsType, mountPoint string, timeout, retries, retryWait uint) error {
+func mountPartitionRetry(label, fsType, mountPoint string, retries, retryWait uint) error {
 	if retries == 0 {
 		retries = 1
 	}
 	var err error = nil
 	for i := uint(0); i < retries; i++ {
-		err := MountPartition(label, fsType, mountPoint, timeout)
+		err := MountPartition(label, fsType, mountPoint)
 		if err == nil {
 			break
 		}
@@ -60,7 +60,7 @@ func mountPartitionRetry(label, fsType, mountPoint string, timeout, retries, ret
 	return err
 }
 
-func MountPartition(label, fsType, mountPoint string, timeout uint) error {
+func MountPartition(label, fsType, mountPoint string) error {
 	devs, err := block.GetBlockDevices()
 	if err != nil {
 		return fmt.Errorf("host storage: %v", err)


### PR DESCRIPTION
  When booting from an USB-stick, the STBOOT and STDATA partition wont be available immediately, and as a result stboot will abort and reset the system. The problem is at the kernel has not reached the point, where the USB-stick can be mounted.

To work-around this, add a retry mechanism around the mount function.

Also, remove the timeout parameter, which was not implemented.

Further; Add a similar retry mechanism to network downloads. Somethings getting the link up on a port takes up to a couple of seconds. Retry, instead of failing immediately.