### PR TITLE
Rework configuration

### DIFF
--- a/stboot/cfg.go
+++ b/stboot/cfg.go
@@ -1,0 +1,198 @@
+package stboot
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	ErrMissingIPAddrMode = InvalidOptsError("IP address mode must be set")
+	ErrUnknownIPAddrMode = InvalidOptsError("unknown IP address mode")
+	ErrMissingProvURLs   = InvalidOptsError("provisioning server URL list must not be empty")
+	ErrInvalidProvURLs   = InvalidOptsError("missing or unsupported scheme in provisioning URLs")
+	ErrMissingIPAddr     = InvalidOptsError("IP address must not be empty when static IP mode is set")
+	ErrMissingGateway    = InvalidOptsError("default gateway must not be empty when static IP mode is set")
+	ErrMissingID         = InvalidOptsError("ID must not be empty when a URL contains '$ID'")
+	ErrInvalidID         = InvalidOptsError("invalid ID string, max 64 characters [a-z,A-Z,0-9,-,_]")
+	ErrMissingAuth       = InvalidOptsError("Auth must not be empty when a URL contains '$AUTH'")
+	ErrInvalidAuth       = InvalidOptsError("invalid auth string, max 64 characters [a-z,A-Z,0-9,-,_]")
+
+	ErrMissingBootMode = InvalidOptsError("boot mode must be set")
+	ErrUnknownBootMode = InvalidOptsError("unknown boot mode")
+)
+
+// BootMode controlls where to load the OS from
+type BootMode int
+
+const (
+	BootModeUnset BootMode = iota
+	LocalBoot
+	NetworkBoot
+)
+
+// String implements fmt.Stringer
+func (b BootMode) String() string {
+	switch b {
+	case BootModeUnset:
+		return "unset"
+	case LocalBoot:
+		return "local"
+	case NetworkBoot:
+		return "network"
+	default:
+		return "unknown"
+	}
+}
+
+// IPAddrMode sets the method for network setup
+type IPAddrMode int
+
+const (
+	IPUnset IPAddrMode = iota
+	IPStatic
+	IPDynamic
+)
+
+// String implements fmt.Stringer
+func (n IPAddrMode) String() string {
+	switch n {
+	case IPUnset:
+		return "unset"
+	case IPStatic:
+		return "static"
+	case IPDynamic:
+		return "DHCP"
+	default:
+		return "unknown"
+	}
+}
+
+// securityCfg contains security critical configurations.
+type securityCfg struct {
+	ValidSignatureThreshold uint
+	BootMode
+	UsePkgCache bool
+}
+
+// hostCfg groups host specific configurations.
+type hostCfg struct {
+	IPAddrMode
+	HostIP           *netlink.Addr
+	DefaultGateway   *net.IP
+	DNSServer        *net.IP
+	NetworkInterface *net.HardwareAddr
+	ProvisioningURLs []*url.URL
+	ID               string
+	Auth             string
+}
+
+// scValidators is a set of functions to validate securityCfg
+var scValidators = []validator{
+	checkBootMode,
+}
+
+// hcValidators is a set of functions to validate hostCfg
+var hcValidators = []validator{
+	checkNetworkMode,
+	checkHostIP,
+	checkGateway,
+	checkProvisioningURLs,
+	checkID,
+	checkAuth,
+}
+
+func checkNetworkMode(o *Opts) error {
+	if o.IPAddrMode == IPUnset {
+		return ErrMissingIPAddrMode
+	}
+	if o.IPAddrMode > IPDynamic {
+		return ErrUnknownIPAddrMode
+	}
+	return nil
+}
+
+func checkHostIP(o *Opts) error {
+	if o.IPAddrMode == IPStatic && o.HostIP == nil {
+		return ErrMissingIPAddr
+	}
+	return nil
+}
+
+func checkGateway(o *Opts) error {
+	if o.IPAddrMode == IPStatic && o.DefaultGateway == nil {
+		return ErrMissingGateway
+	}
+	return nil
+}
+
+func checkProvisioningURLs(o *Opts) error {
+	if len(o.ProvisioningURLs) == 0 {
+		return ErrMissingProvURLs
+	}
+	for _, u := range o.ProvisioningURLs {
+		s := u.Scheme
+		if s == "" || s != "http" && s != "https" {
+			return ErrInvalidProvURLs
+		}
+	}
+	return nil
+}
+
+func checkID(o *Opts) error {
+	var used bool
+	for _, u := range o.ProvisioningURLs {
+		if used = strings.Contains(u.String(), "$ID"); used {
+			break
+		}
+	}
+	if used {
+		if o.ID == "" {
+			return ErrMissingID
+		} else if !hasAllowdChars(o.ID) {
+			return ErrInvalidID
+		}
+	}
+	return nil
+}
+
+func checkAuth(o *Opts) error {
+	var used bool
+	for _, u := range o.ProvisioningURLs {
+		if used = strings.Contains(u.String(), "$AUTH"); used {
+			break
+		}
+	}
+	if used {
+		if o.Auth == "" {
+			return ErrMissingAuth
+		} else if !hasAllowdChars(o.Auth) {
+			return ErrInvalidAuth
+		}
+	}
+	return nil
+}
+
+func hasAllowdChars(s string) bool {
+	if len(s) > 64 {
+		return false
+	}
+	for _, c := range s {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func checkBootMode(o *Opts) error {
+	if o.BootMode == BootModeUnset {
+		return ErrMissingBootMode
+	}
+	if o.BootMode > NetworkBoot {
+		return ErrUnknownBootMode
+	}
+	return nil
+}

--- a/stboot/stboot.go
+++ b/stboot/stboot.go
@@ -1,0 +1,26 @@
+package stboot
+
+const OptsVersion int = 1
+
+type InvalidOptsError string
+
+func (e InvalidOptsError) Error() string {
+	return string(e)
+}
+
+type validator func(*Opts) error
+
+type Opts struct {
+	Version int
+	securityCfg
+	hostCfg
+}
+
+func (o *Opts) validate(v ...validator) error {
+	for _, f := range v {
+		if err := f(o); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/stboot/stboot_test.go
+++ b/stboot/stboot_test.go
@@ -1,0 +1,381 @@
+package stboot
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestInvalidOptsError(t *testing.T) {
+	msg := "some error message"
+	err := InvalidOptsError(msg)
+
+	got := err.Error()
+	if got != msg {
+		t.Errorf("got %q, want %q", got, msg)
+	}
+}
+
+func TestBootMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode BootMode
+		want string
+	}{
+		{
+			name: "String for default value",
+			mode: BootModeUnset,
+			want: "unset",
+		},
+		{
+			name: "String for 'LocalBoot'",
+			mode: LocalBoot,
+			want: "local",
+		},
+		{
+			name: "String for 'NetworkBoot'",
+			mode: NetworkBoot,
+			want: "network",
+		},
+		{
+			name: "String for unknown value",
+			mode: 3,
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPAddrMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode IPAddrMode
+		want string
+	}{
+		{
+			name: "String for default value",
+			mode: IPUnset,
+			want: "unset",
+		},
+		{
+			name: "String for 'IPStatic'",
+			mode: IPStatic,
+			want: "static",
+		},
+		{
+			name: "String for 'IPDynamic'",
+			mode: IPDynamic,
+			want: "DHCP",
+		},
+		{
+			name: "String for unknown value",
+			mode: 3,
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecurityCfgValidation(t *testing.T) {
+	validSecurityCfgTests := []struct {
+		name string
+		cfg  securityCfg
+	}{
+		{
+			name: "Minimum valid config with implicit defaults",
+			cfg: securityCfg{
+				BootMode: LocalBoot,
+			},
+		},
+		{
+			name: "Minimum valid config with explicit values",
+			cfg: securityCfg{
+				ValidSignatureThreshold: 1,
+				BootMode:                NetworkBoot,
+				UsePkgCache:             true,
+			},
+		},
+	}
+
+	invalidSecurityCfgTests := []struct {
+		name string
+		cfg  securityCfg
+		want error
+	}{
+		{
+			name: "Empty boot mode",
+			cfg:  securityCfg{},
+			want: ErrMissingBootMode,
+		},
+		{
+			name: "Unknown boot mode",
+			cfg: securityCfg{
+				BootMode: 3,
+			},
+			want: ErrUnknownBootMode,
+		},
+	}
+
+	for _, tt := range validSecurityCfgTests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := Opts{securityCfg: tt.cfg}
+			err := o.validate(scValidators...)
+
+			assertNoError(t, err)
+		})
+	}
+
+	for _, tt := range invalidSecurityCfgTests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := Opts{securityCfg: tt.cfg}
+			err := o.validate(scValidators...)
+
+			assertError(t, err, tt.want)
+		})
+	}
+}
+
+func TestHostCfgValidation(t *testing.T) {
+
+	invalidURL1, _ := url.Parse("foo.com/bar")
+	invalidURL2, _ := url.Parse("ftp://foo.com/bar")
+	validURL1, _ := url.Parse("http://foo.com/bar")
+	validURL2, _ := url.Parse("https://foo.com/bar")
+	urlWithID, _ := url.Parse("http://foo.com/$ID/bar")
+	urlWithIDandAuth, _ := url.Parse("http://foo.com/$ID/$AUTH/bar")
+	gw := net.ParseIP("127.0.0.1")
+	ip, _ := netlink.ParseAddr("127.0.0.1/24")
+
+	validHostCfgTests := []struct {
+		name string
+		cfg  hostCfg
+	}{
+		{
+			name: "Minimum valid config with dynamic IP address",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{validURL1},
+			},
+		},
+		{
+			name: "Minimum valid config with static IP address",
+			cfg: hostCfg{
+				IPAddrMode:       IPStatic,
+				HostIP:           ip,
+				DefaultGateway:   &gw,
+				ProvisioningURLs: []*url.URL{validURL1},
+			},
+		},
+	}
+
+	invalidHostCfgTests := []struct {
+		name string
+		cfg  hostCfg
+		want error
+	}{
+		{
+			name: "Missing IP address mode",
+			cfg: hostCfg{
+				ProvisioningURLs: []*url.URL{validURL1},
+			},
+			want: ErrMissingIPAddrMode,
+		},
+		{
+			name: "Unknown IP address mode",
+			cfg: hostCfg{
+				IPAddrMode:       3,
+				ProvisioningURLs: []*url.URL{validURL1},
+			},
+			want: ErrUnknownIPAddrMode,
+		},
+		{
+			name: "Missing IP address",
+			cfg: hostCfg{
+				IPAddrMode:       IPStatic,
+				ProvisioningURLs: []*url.URL{validURL1},
+				DefaultGateway:   &gw,
+			},
+			want: ErrMissingIPAddr,
+		},
+		{
+			name: "Missing gateway",
+			cfg: hostCfg{
+				IPAddrMode:       IPStatic,
+				ProvisioningURLs: []*url.URL{validURL1},
+				HostIP:           ip,
+			},
+			want: ErrMissingGateway,
+		},
+		{
+			name: "Missing URLs",
+			cfg: hostCfg{
+				IPAddrMode: IPDynamic,
+			},
+			want: ErrMissingProvURLs,
+		},
+		{
+			name: "Invalid URLs 1",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{validURL1, invalidURL1},
+			},
+			want: ErrInvalidProvURLs,
+		},
+		{
+			name: "Invalid URLs 2",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{validURL2, invalidURL2},
+			},
+			want: ErrInvalidProvURLs,
+		},
+		{
+			name: "Missing ID",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithID},
+			},
+			want: ErrMissingID,
+		},
+		{
+			name: "Invalid ID 1",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithID},
+				ID:               "abc/1",
+			},
+			want: ErrInvalidID,
+		},
+		{
+			name: "Invalid ID 2",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithID},
+				ID:               "abc:1",
+			},
+			want: ErrInvalidID,
+		},
+		{
+			name: "Invalid ID 3",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithID},
+				ID:               "abc@1",
+			},
+			want: ErrInvalidID,
+		},
+		{
+			name: "Invalid ID 4",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithID},
+				ID:               strings.Repeat("a", 65),
+			},
+			want: ErrInvalidID,
+		},
+		{
+			name: "Missing Auth",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithIDandAuth},
+				ID:               "abc",
+			},
+			want: ErrMissingAuth,
+		},
+		{
+			name: "Invalid Auth 1",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithIDandAuth},
+				ID:               "abc",
+				Auth:             "abc/1",
+			},
+			want: ErrInvalidAuth,
+		},
+		{
+			name: "Invalid Auth 2",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithIDandAuth},
+				ID:               "abc",
+				Auth:             "abc:1",
+			},
+			want: ErrInvalidAuth,
+		},
+		{
+			name: "Invalid Auth 3",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithIDandAuth},
+				ID:               "abc",
+				Auth:             "abc@1",
+			},
+			want: ErrInvalidAuth,
+		},
+		{
+			name: "Invalid Auth 4",
+			cfg: hostCfg{
+				IPAddrMode:       IPDynamic,
+				ProvisioningURLs: []*url.URL{urlWithIDandAuth},
+				ID:               "abc",
+				Auth:             strings.Repeat("a", 65),
+			},
+			want: ErrInvalidAuth,
+		},
+	}
+
+	for _, tt := range validHostCfgTests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := Opts{hostCfg: tt.cfg}
+			err := o.validate(hcValidators...)
+
+			assertNoError(t, err)
+		})
+	}
+
+	for _, tt := range invalidHostCfgTests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := Opts{hostCfg: tt.cfg}
+			err := o.validate(hcValidators...)
+
+			assertError(t, err, tt.want)
+		})
+	}
+}
+
+func assertError(t testing.TB, got, want error) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("expected an error")
+	}
+
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func assertNoError(t testing.TB, got error) {
+	t.Helper()
+	if got != nil {
+		t.Errorf("didn't expect an error but got: %v", got)
+	}
+}


### PR DESCRIPTION
The separation between host config and security config is not relevant to the internal state of the stboot command. The idea is to introduce a general Opts struct meant to store all configuration and settings for stboot. Still, the parsing of separated host and security settings from remain untouched. 
The source of host config and security config settings may vary, e.g. JSON, cmd line, hard drive, NVRAM, ...
