### PR TITLE
Make {host,security}_configuration.json parsing stricter.

### DIFF
--- a/config/host_config_json_parser.go
+++ b/config/host_config_json_parser.go
@@ -45,6 +45,7 @@ type rawCfg map[string]interface{}
 type hostCfgParser func(rawCfg, *HostCfg) error
 
 var hostCfgParsers = []hostCfgParser{
+	parseHostKeys,
 	parseHostCfgVersion,
 	parseNetworkMode,
 	parseHostIP,
@@ -80,16 +81,45 @@ func (hp *HostCfgJSONParser) Parse() (*HostCfg, error) {
 	return cfg, nil
 }
 
+func parseHostKeys(r rawCfg, c *HostCfg) error {
+	for key := range r {
+		switch key {
+		case HostCfgVersionJSONKey:
+			continue
+		case NetworkModeJSONKey:
+			continue
+		case HostIPJSONKey:
+			continue
+		case DefaultGatewayJSONKey:
+			continue
+		case DNSServerJSONKey:
+			continue
+		case NetworkInterfaceJSONKey:
+			continue
+		case ProvisioningURLsJSONKey:
+			continue
+		case IdJSONKey:
+			continue
+		case AuthJSONKey:
+			continue
+		default:
+			return &ParseError{key, fmt.Errorf("bad key")}
+		}
+	}
+	return nil
+}
+
 func parseHostCfgVersion(r rawCfg, c *HostCfg) error {
 	key := HostCfgVersionJSONKey
 	if val, found := r[key]; found {
 		if ver, ok := val.(float64); ok {
 			c.Version = int(ver)
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseNetworkMode(r rawCfg, c *HostCfg) error {
@@ -106,11 +136,12 @@ func parseNetworkMode(r rawCfg, c *HostCfg) error {
 			default:
 				return &ParseError{key, fmt.Errorf("unknown network mode %q", m)}
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseHostIP(r rawCfg, c *HostCfg) error {
@@ -124,11 +155,12 @@ func parseHostIP(r rawCfg, c *HostCfg) error {
 				}
 				c.HostIP = ip
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseDefaultGateway(r rawCfg, c *HostCfg) error {
@@ -142,11 +174,12 @@ func parseDefaultGateway(r rawCfg, c *HostCfg) error {
 				}
 				c.DefaultGateway = &ip
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseDNSServer(r rawCfg, c *HostCfg) error {
@@ -160,11 +193,12 @@ func parseDNSServer(r rawCfg, c *HostCfg) error {
 				}
 				c.DNSServer = &ip
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseNetworkInterface(r rawCfg, c *HostCfg) error {
@@ -178,11 +212,12 @@ func parseNetworkInterface(r rawCfg, c *HostCfg) error {
 				}
 				c.NetworkInterface = &mac
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseProvisioningURLs(r rawCfg, c *HostCfg) error {
@@ -204,11 +239,12 @@ func parseProvisioningURLs(r rawCfg, c *HostCfg) error {
 					return &TypeError{key, v}
 				}
 			}
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseID(r rawCfg, c *HostCfg) error {
@@ -216,11 +252,12 @@ func parseID(r rawCfg, c *HostCfg) error {
 	if val, found := r[key]; found {
 		if id, ok := val.(string); ok {
 			c.ID = id
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }
 
 func parseAuth(r rawCfg, c *HostCfg) error {
@@ -228,9 +265,10 @@ func parseAuth(r rawCfg, c *HostCfg) error {
 	if val, found := r[key]; found {
 		if a, ok := val.(string); ok {
 			c.Auth = a
+			return nil
 		} else {
 			return &TypeError{key, val}
 		}
 	}
-	return nil
+	return &ParseError{key, fmt.Errorf("missing key")}
 }

--- a/config/testdata/host_authentication_bad.json
+++ b/config/testdata/host_authentication_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":1
+}

--- a/config/testdata/host_dns_bad.json
+++ b/config/testdata/host_dns_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8...8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_empty_good.json
+++ b/config/testdata/host_empty_good.json
@@ -1,0 +1,11 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_gateway_bad.json
+++ b/config/testdata/host_gateway_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2/24",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_host_ip_bad.json
+++ b/config/testdata/host_host_ip_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15../24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_identity_bad.json
+++ b/config/testdata/host_identity_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":1,
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_missing_0_bad.json
+++ b/config/testdata/host_missing_0_bad.json
@@ -1,0 +1,10 @@
+{
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_1_bad.json
+++ b/config/testdata/host_missing_1_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_2_bad.json
+++ b/config/testdata/host_missing_2_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_3_bad.json
+++ b/config/testdata/host_missing_3_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_4_bad.json
+++ b/config/testdata/host_missing_4_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_5_bad.json
+++ b/config/testdata/host_missing_5_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "provisioning_urls":[],
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_6_bad.json
+++ b/config/testdata/host_missing_6_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "identity":"",
+    "authentication":""
+}

--- a/config/testdata/host_missing_7_bad.json
+++ b/config/testdata/host_missing_7_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "authentication":""
+}

--- a/config/testdata/host_missing_8_bad.json
+++ b/config/testdata/host_missing_8_bad.json
@@ -1,0 +1,10 @@
+{
+    "version":0,
+    "network_mode":"",
+    "host_ip":"",
+    "gateway":"",
+    "dns":"",
+    "network_interface":"",
+    "provisioning_urls":[],
+    "identity":""
+}

--- a/config/testdata/host_network_interface_bad.json
+++ b/config/testdata/host_network_interface_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"some string",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_network_mode_1_good.json
+++ b/config/testdata/host_network_mode_1_good.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"static",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_network_mode_2_good.json
+++ b/config/testdata/host_network_mode_2_good.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_network_mode_bad.json
+++ b/config/testdata/host_network_mode_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":1,
+    "network_mode":"some string",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/host_provisioning_urls_bad.json
+++ b/config/testdata/host_provisioning_urls_bad.json
@@ -1,0 +1,12 @@
+{
+    "version":1,
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["missing.scheme/in/url"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}
+

--- a/config/testdata/host_version_bad.json
+++ b/config/testdata/host_version_bad.json
@@ -1,0 +1,11 @@
+{
+    "version":"one",
+    "network_mode":"dhcp",
+    "host_ip":"10.0.2.15/24",
+    "gateway":"10.0.2.2",
+    "dns":"8.8.8.8",
+    "network_interface":"00:00:5e:00:53:01",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
+    "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
+    "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
+}

--- a/config/testdata/sec_boot_mode_1_good.json
+++ b/config/testdata/sec_boot_mode_1_good.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "local",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_boot_mode_2_good.json
+++ b/config/testdata/sec_boot_mode_2_good.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_boot_mode_bad.json
+++ b/config/testdata/sec_boot_mode_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "some string",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_boot_mode_type_bad.json
+++ b/config/testdata/sec_boot_mode_type_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": 1,
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_empty_good.json
+++ b/config/testdata/sec_empty_good.json
@@ -1,0 +1,6 @@
+{
+    "version": 0,
+    "min_valid_sigs_required": 0,
+    "boot_mode": "",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_min_valid_sign_bad.json
+++ b/config/testdata/sec_min_valid_sign_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": -1,
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_min_valid_sign_type_bad.json
+++ b/config/testdata/sec_min_valid_sign_type_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": "one",
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_missing_0_bad.json
+++ b/config/testdata/sec_missing_0_bad.json
@@ -1,0 +1,5 @@
+{
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_missing_1_bad.json
+++ b/config/testdata/sec_missing_1_bad.json
@@ -1,0 +1,5 @@
+{
+    "version": 1,
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_missing_2_bad.json
+++ b/config/testdata/sec_missing_2_bad.json
@@ -1,0 +1,5 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "use_ospkg_cache": false
+}

--- a/config/testdata/sec_missing_3_bad.json
+++ b/config/testdata/sec_missing_3_bad.json
@@ -1,0 +1,5 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network"
+}

--- a/config/testdata/sec_use_pkg_cache_1_type_bad.json
+++ b/config/testdata/sec_use_pkg_cache_1_type_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network",
+    "use_ospkg_cache": 1
+}

--- a/config/testdata/sec_use_pkg_cache_2_type_bad.json
+++ b/config/testdata/sec_use_pkg_cache_2_type_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network",
+    "use_ospkg_cache": "true"
+}

--- a/config/testdata/sec_version_type_bad.json
+++ b/config/testdata/sec_version_type_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": "one",
+    "min_valid_sigs_required": 2,
+    "boot_mode": "network",
+    "use_ospkg_cache": false
+}


### PR DESCRIPTION
When configuring stboot via the JSON files, all fields should be
always be explicitly typed out. If not, this should be considered an
error. This improves the experience for the user in the following
ways:
 * A user will be aware of the available configuration options
 * It is harder for a user to do misconfiguration

The JSON tests were rewritten, but keeping the old tests. New tests to
check for missing fields were added.

Signed-off-by: Björn Töpel <bjorn@mullvad.net>