### PR TITLE
fix codecov coverage calculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: Go
+name: Build
 on:
   push:
   pull_request:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,5 +62,6 @@ jobs:
       - name: Run coverage
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Testing
+name: Test
 on:
   push:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # stboot
 
-[![Testing](https://github.com/system-transparency/stboot/actions/workflows/testing.yml/badge.svg)](https://github.com/system-transparency/stboot/actions/workflows/testing.yml)
+[![Build](https://github.com/system-transparency/stboot/actions/workflows/build.yml/badge.svg)](https://github.com/system-transparency/stboot/actions/workflows/build.yml)
+[![Test](https://github.com/system-transparency/stboot/actions/workflows/test.yml/badge.svg)](https://github.com/system-transparency/stboot/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/system-transparency/stboot/branch/main/graph/badge.svg)](https://codecov.io/gh/system-transparency/stboot)
 
 The reference bootloader implementation for System Transparency.

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 the System Transparency Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package host
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	//TODO
+}

--- a/host/network/network_test.go
+++ b/host/network/network_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 the System Transparency Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package network
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	//TODO
+}

--- a/stboot_test.go
+++ b/stboot_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 the System Transparency Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	//TODO
+}

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 the System Transparency Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package trust
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	//TODO
+}


### PR DESCRIPTION
Codecov does not take into account packages without tests.
Add teststubs (empty test files) to get the actual code coverage

In addition, make both workflow name more descriptive:
Go -> Build
Testing -> Test