### PR TITLE
stboot: Add host-config flag

### DIFF
--- a/.github/scripts/qemu.sh
+++ b/.github/scripts/qemu.sh
@@ -54,7 +54,7 @@ qemu-system-x86_64 -nographic -kernel "$root/.github/assets/vmlinuz" \
 	-device virtio-rng-pci,rng=rng0 \
 	-rtc base=localtime \
 	-nographic \
-	-append "console=ttyS0,115200 uroot.uinitargs=\"-debug -initrdhostcfg -labsetup\"" \
+	-append "console=ttyS0,115200 uroot.uinitargs=\"-debug\"" \
 	-initrd $out/initramfs.cpio </dev/null | tee /dev/stderr > "$LOG" &
 
 i=0


### PR DESCRIPTION
This PR implements the host-config flag. #41

Add `-host-config` flag to define the location of the host configuration
file. In the current state, there are 3 ways to store this configuration:
1. inside initramfs: -host-config=/path/to/host_configuration.json
2. as efivar: -host-config=efivar:STDATA-d736a263-c838-4702-9df4-50134ad8a636
3. inside STBOOT at a fix location: -host-config=legacy

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>