### PR TITLE
stboot: Add cdrom support to host-config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/u-root/u-root v0.0.0-20210617013441-63b0ffe37ca5
 	github.com/vishvananda/netlink v1.1.1-0.20200221165523-c79a4b7b4066
 	golang.org/x/crypto v0.0.0-20210415154028-4f45737414dc // indirect
+	golang.org/x/sys v0.0.0-20211020174200-9d6173849985
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,6 +68,7 @@ github.com/vishvananda/netns
 # golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 golang.org/x/net/bpf
 # golang.org/x/sys v0.0.0-20211020174200-9d6173849985
+## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c


### PR DESCRIPTION
Add "cdrom:" prefix support for the -host-config flag. This will make
stboot mounting /dev/sr0, and look for the host configuration at the
provided path.

Also rework the retry mechanism, so it is more generic and support
cdrom mounts in addition to GPT mounts.

An example:
  -host-config=cdrom:/host_configuration.json

Signed-off-by: Björn Töpel <bjorn@mullvad.net>