### PR TITLE
Opts: Remove New'Loader'Struct functions

### DIFF
--- a/opts/hostcfg.go
+++ b/opts/hostcfg.go
@@ -300,21 +300,16 @@ func (t *timeTime) UnmarshalJSON(data []byte) error {
 
 // HostCfgJSON initializes Opts's HostCfg from JSON.
 type HostCfgJSON struct {
-	src io.Reader
-}
-
-// NewHostCfgJSON returns a new HostCfgJSON with the given io.Reader.
-func NewHostCfgJSON(src io.Reader) *HostCfgJSON {
-	return &HostCfgJSON{src}
+	io.Reader
 }
 
 // Load implements Loader.
 func (h *HostCfgJSON) Load(o *Opts) error {
 	var hc HostCfg
-	if h.src == nil {
+	if h.Reader == nil {
 		return errors.New("no source provided")
 	}
-	d := json.NewDecoder(h.src)
+	d := json.NewDecoder(h.Reader)
 	if err := d.Decode(&hc); err != nil {
 		return err
 	}
@@ -325,17 +320,12 @@ func (h *HostCfgJSON) Load(o *Opts) error {
 
 // HostCfgFile wraps SecurityJSON.
 type HostCfgFile struct {
-	name string
-}
-
-// NewHostCfgFile returns a new HostCfgFile with the given name.
-func NewHostCfgFile(name string) *HostCfgFile {
-	return &HostCfgFile{name}
+	Name string
 }
 
 // Load implements Loader.
 func (h *HostCfgFile) Load(o *Opts) error {
-	f, err := os.Open(h.name)
+	f, err := os.Open(h.Name)
 	if err != nil {
 		return err
 	}

--- a/opts/hostcfg_test.go
+++ b/opts/hostcfg_test.go
@@ -1119,11 +1119,11 @@ func TestTimeTimeUnmarshal(t *testing.T) {
 }
 
 func TestHotCfgJSONLoadNew(t *testing.T) {
-	got := NewHostCfgJSON(&bytes.Buffer{})
+	got := &HostCfgJSON{Reader: &bytes.Buffer{}}
 	if got == nil {
 		t.Fatal("expect non-nil return")
 	}
-	if got.src == nil {
+	if got.Reader == nil {
 		t.Error("expect src to be initialized")
 	}
 }
@@ -1146,7 +1146,7 @@ func TestHostCfgJSONLoad(t *testing.T) {
 		{
 			name: "Successful loading",
 			loader: HostCfgJSON{
-				src: bytes.NewBuffer(goodJSON),
+				Reader: bytes.NewBuffer(goodJSON),
 			},
 			errType: nil,
 		},
@@ -1158,14 +1158,14 @@ func TestHostCfgJSONLoad(t *testing.T) {
 		{
 			name: "Bad source",
 			loader: HostCfgJSON{
-				src: bytes.NewBufferString("bad"),
+				Reader: bytes.NewBufferString("bad"),
 			},
 			errType: &json.SyntaxError{},
 		},
 		{
 			name: "Bad content",
 			loader: HostCfgJSON{
-				src: bytes.NewBuffer(badJSON),
+				Reader: bytes.NewBuffer(badJSON),
 			},
 			errType: InvalidError(""),
 		},
@@ -1180,7 +1180,7 @@ func TestHostCfgJSONLoad(t *testing.T) {
 }
 
 func TestHostCfgFileNew(t *testing.T) {
-	got := NewHostCfgFile("some/name")
+	got := &HostCfgFile{Name: "some/name"}
 	if got == nil {
 		t.Fatal("expect non-nil return")
 	}
@@ -1198,7 +1198,7 @@ func TestHostCfgFileLoad(t *testing.T) {
 		{
 			name: "Successful loading",
 			loader: HostCfgFile{
-				name: goodJSON,
+				Name: goodJSON,
 			},
 			errType: nil,
 		},
@@ -1210,14 +1210,14 @@ func TestHostCfgFileLoad(t *testing.T) {
 		{
 			name: "Bad file",
 			loader: HostCfgFile{
-				name: "not/exist",
+				Name: "not/exist",
 			},
 			errType: &fs.PathError{},
 		},
 		{
 			name: "Bad content",
 			loader: HostCfgFile{
-				name: badJSON,
+				Name: badJSON,
 			},
 			errType: InvalidError(""),
 		},

--- a/opts/integration_test.go
+++ b/opts/integration_test.go
@@ -44,7 +44,7 @@ func TestOptsLoader(t *testing.T) {
 		Security: sc,
 		HostCfg:  hc,
 	}
-	got, err := NewOpts(NewSecurityFile(scPath), NewHostCfgFile(hcPath))
+	got, err := NewOpts(&SecurityFile{Name: scPath}, &HostCfgFile{Name: hcPath})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/opts/security.go
+++ b/opts/security.go
@@ -103,21 +103,16 @@ func (s *Security) UnmarshalJSON(data []byte) error {
 
 // SecurityCfgJSON initialzes Opts's Security from JSON.
 type SecurityJSON struct {
-	src io.Reader
-}
-
-// NewSecurityJSON returns a new SecurityJSON with the given io.Reader.
-func NewSecurityJSON(src io.Reader) *SecurityJSON {
-	return &SecurityJSON{src}
+	io.Reader
 }
 
 // Load implements Loader.
 func (s *SecurityJSON) Load(o *Opts) error {
 	var sc Security
-	if s.src == nil {
+	if s.Reader == nil {
 		return errors.New("no source provided")
 	}
-	d := json.NewDecoder(s.src)
+	d := json.NewDecoder(s.Reader)
 	if err := d.Decode(&sc); err != nil {
 		return err
 	}
@@ -127,17 +122,12 @@ func (s *SecurityJSON) Load(o *Opts) error {
 
 // SecurityFile wrapps SecurityJSON.
 type SecurityFile struct {
-	name string
-}
-
-// NewSecurityFile returns a new SecurityFile with the given name.
-func NewSecurityFile(name string) *SecurityFile {
-	return &SecurityFile{name}
+	Name string
 }
 
 // Load implements Loader.
 func (s *SecurityFile) Load(o *Opts) error {
-	f, err := os.Open(s.name)
+	f, err := os.Open(s.Name)
 	if err != nil {
 		return err
 	}

--- a/opts/security_test.go
+++ b/opts/security_test.go
@@ -229,11 +229,11 @@ func TestSecurityUnmarshalJSON(t *testing.T) {
 }
 
 func TestSecurityJSONLoadNew(t *testing.T) {
-	got := NewSecurityJSON(&bytes.Buffer{})
+	got := &SecurityJSON{Reader: &bytes.Buffer{}}
 	if got == nil {
 		t.Fatal("expect non-nil return")
 	}
-	if got.src == nil {
+	if got.Reader == nil {
 		t.Error("expect src to be initialized")
 	}
 }
@@ -256,7 +256,7 @@ func TestSecurityJSONLoad(t *testing.T) {
 		{
 			name: "Successful loading",
 			loader: SecurityJSON{
-				src: bytes.NewBuffer(goodJSON),
+				Reader: bytes.NewBuffer(goodJSON),
 			},
 			errType: nil,
 		},
@@ -268,14 +268,14 @@ func TestSecurityJSONLoad(t *testing.T) {
 		{
 			name: "Bad source",
 			loader: SecurityJSON{
-				src: bytes.NewBufferString("bad"),
+				Reader: bytes.NewBufferString("bad"),
 			},
 			errType: &json.SyntaxError{},
 		},
 		{
 			name: "Bad content",
 			loader: SecurityJSON{
-				src: bytes.NewBuffer(badJSON),
+				Reader: bytes.NewBuffer(badJSON),
 			},
 			errType: InvalidError(""),
 		},
@@ -290,7 +290,7 @@ func TestSecurityJSONLoad(t *testing.T) {
 }
 
 func TestSecurityFileNew(t *testing.T) {
-	got := NewSecurityFile("some/name")
+	got := &SecurityFile{Name: "some/name"}
 	if got == nil {
 		t.Fatal("expect non-nil return")
 	}
@@ -308,7 +308,7 @@ func TestSecurityFileLoad(t *testing.T) {
 		{
 			name: "Successful loading",
 			loader: SecurityFile{
-				name: goodJSON,
+				Name: goodJSON,
 			},
 			errType: nil,
 		},
@@ -320,14 +320,14 @@ func TestSecurityFileLoad(t *testing.T) {
 		{
 			name: "Bad file",
 			loader: SecurityFile{
-				name: "not/exist",
+				Name: "not/exist",
 			},
 			errType: &fs.PathError{},
 		},
 		{
 			name: "Bad content",
 			loader: SecurityFile{
-				name: badJSON,
+				Name: badJSON,
 			},
 			errType: InvalidError(""),
 		},

--- a/stboot.go
+++ b/stboot.go
@@ -161,7 +161,7 @@ func main() {
 	// Define loader for https root certificate
 	httpsRootLoader = &opts.HttpsRootsFile{File: httpsRootsFile}
 
-	securityLoader = opts.NewSecurityFile(securityConfigFile)
+	securityLoader = &opts.SecurityFile{Name: securityConfigFile}
 
 	switch hostCfg.location {
 	case hostCfgEfivar:
@@ -176,9 +176,9 @@ func main() {
 			stlog.Error("reading efivar %q: %v", hostCfg.name, err)
 			host.Recover()
 		}
-		hostCfgLoader = opts.NewHostCfgJSON(&r)
+		hostCfgLoader = &opts.HostCfgJSON{Reader: &r}
 	case hostCfgInitramfs:
-		hostCfgLoader = opts.NewHostCfgFile(hostCfg.name)
+		hostCfgLoader = &opts.HostCfgFile{Name: hostCfg.name}
 	case hostCfgLegacy:
 		// Mount STBOOT partition
 		if err := host.MountBootPartition(); err != nil {
@@ -186,14 +186,14 @@ func main() {
 			host.Recover()
 		}
 		p := filepath.Join(host.BootPartitionMountPoint, hostCfg.name)
-		hostCfgLoader = opts.NewHostCfgFile(p)
+		hostCfgLoader = &opts.HostCfgFile{Name: p}
 	case hostCfgCdrom:
 		if err := host.MountCdrom(); err != nil {
 			stlog.Error("mount CDROM: %v", err)
 			host.Recover()
 		}
 		p := filepath.Join(host.BootPartitionMountPoint, hostCfg.name)
-		hostCfgLoader = opts.NewHostCfgFile(p)
+		hostCfgLoader = &opts.HostCfgFile{Name: p}
 	}
 
 	stOptions, err := opts.NewOpts(securityLoader, hostCfgLoader, signingRootLoader, httpsRootLoader)


### PR DESCRIPTION
opts: 
* Make field name of loader structs public & remove New functions for Loader structs.

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>