### PR TITLE
Remove ioutil from the codebase

### DIFF
--- a/host/network/network.go
+++ b/host/network/network.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -148,7 +147,7 @@ func SetDNSServer(dns net.IP) error {
 	resolvconf := fmt.Sprintf("nameserver %s\n", dns.String())
 
 	const perm = 0644
-	if err := ioutil.WriteFile("/etc/resolv.conf", []byte(resolvconf), perm); err != nil {
+	if err := os.WriteFile("/etc/resolv.conf", []byte(resolvconf), perm); err != nil {
 		return sterror.E(ErrScope, ErrOpSetDNSServer, ErrNetworkConfiguration, err.Error())
 	}
 
@@ -274,7 +273,7 @@ func Download(url *url.URL, httpsRoots *x509.CertPool, insecure bool) ([]byte, e
 		resp.Body = progress(resp.Body)
 	}
 
-	ret, err := ioutil.ReadAll(resp.Body)
+	ret, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, sterror.E(ErrScope, ErrOpDownload, ErrDownload, err.Error())
 	}
@@ -289,7 +288,7 @@ func Download(url *url.URL, httpsRoots *x509.CertPool, insecure bool) ([]byte, e
 func CheckEntropy() {
 	const minEntropy = 128
 
-	e, err := ioutil.ReadFile(entropyAvail)
+	e, err := os.ReadFile(entropyAvail)
 	if err != nil {
 		stlog.Warn("Entropy check failed, %v", err)
 	}

--- a/opts/certs.go
+++ b/opts/certs.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/system-transparency/stboot/stlog"
 )
@@ -62,7 +62,7 @@ func (h *HTTPSRootsFile) Load(opts *Opts) error {
 }
 
 func decodePem(file string) ([]*x509.Certificate, error) {
-	pemBytes, err := ioutil.ReadFile(file)
+	pemBytes, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %w", err)
 	}

--- a/ospkg/descriptor.go
+++ b/ospkg/descriptor.go
@@ -7,8 +7,8 @@ package ospkg
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 
 	"github.com/system-transparency/stboot/sterror"
 	"github.com/system-transparency/stboot/stlog"
@@ -39,7 +39,7 @@ type Descriptor struct {
 
 // DescriptorFromFile parses a manifest from a json file.
 func DescriptorFromFile(src string) (*Descriptor, error) {
-	bytes, err := ioutil.ReadFile(src)
+	bytes, err := os.ReadFile(src)
 	if err != nil {
 		return nil, sterror.E(ErrScope, ErrOpDescFromFile, ErrParse, err.Error())
 	}

--- a/ospkg/manifest.go
+++ b/ospkg/manifest.go
@@ -7,7 +7,6 @@ package ospkg
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -80,7 +79,7 @@ func (m *OSManifest) Write(dir string) error {
 
 	dst := filepath.Join(dir, ManifestName)
 
-	err = ioutil.WriteFile(dst, buf, os.ModePerm)
+	err = os.WriteFile(dst, buf, os.ModePerm)
 	if err != nil {
 		return sterror.E(ErrScope, ErrOpOSMWrite, ErrWriteToFile, err.Error())
 	}

--- a/ospkg/os_pkg.go
+++ b/ospkg/os_pkg.go
@@ -12,8 +12,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/system-transparency/stboot/sterror"
@@ -122,7 +122,7 @@ func CreateOSPackage(label, pkgURL, kernel, initramfs, cmdline string) (*OSPacka
 	}
 
 	if kernel != "" {
-		osp.kernel, err = ioutil.ReadFile(kernel)
+		osp.kernel, err = os.ReadFile(kernel)
 		if err != nil {
 			return nil, sterror.E(ErrScope, ErrOpCreateOSPkg, ErrGenerateData, fmt.Sprintf(ErrInfoFailedToReadFrom, "kernel"))
 		}
@@ -131,7 +131,7 @@ func CreateOSPackage(label, pkgURL, kernel, initramfs, cmdline string) (*OSPacka
 	}
 
 	if initramfs != "" {
-		osp.initramfs, err = ioutil.ReadFile(initramfs)
+		osp.initramfs, err = os.ReadFile(initramfs)
 		if err != nil {
 			return nil, sterror.E(ErrScope, ErrOpCreateOSPkg, ErrGenerateData, fmt.Sprintf(ErrInfoFailedToReadFrom, "initramfs"))
 		}

--- a/stboot.go
+++ b/stboot.go
@@ -12,7 +12,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -343,14 +342,14 @@ func main() {
 	for _, sample := range ospkgSampls {
 		stlog.Info("Processing OS package %s", sample.name)
 
-		aBytes, err := ioutil.ReadAll(sample.archive)
+		aBytes, err := io.ReadAll(sample.archive)
 		if err != nil {
 			stlog.Debug("Read archive: %v", err)
 
 			continue
 		}
 
-		dBytes, err := ioutil.ReadAll(sample.descriptor)
+		dBytes, err := io.ReadAll(sample.descriptor)
 		if err != nil {
 			stlog.Debug("Read archive: %v", err)
 
@@ -497,7 +496,7 @@ func markCurrentOSpkg(pkgPath string) {
 	f := filepath.Join(host.DataPartitionMountPoint, host.CurrentOSPkgFile)
 	current := pkgPath + string('\n')
 
-	if err := ioutil.WriteFile(f, []byte(current), os.ModePerm); err != nil {
+	if err := os.WriteFile(f, []byte(current), os.ModePerm); err != nil {
 		stlog.Error("write current OS package: %v", err)
 		host.Recover()
 	}


### PR DESCRIPTION
This was deprecated with go 1.16 and most functions was moved to the os
package.

Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>