### PR TITLE
Morten/fix bond

### DIFF
--- a/host/network/network.go
+++ b/host/network/network.go
@@ -363,6 +363,8 @@ func SetupBondInterface(ifaceName string, mode netlink.BondMode) (*netlink.Bond,
 	bond := netlink.NewLinkBond(la)
 	bond.Mode = mode
 
+	bond.Miimon = 100
+
 	if bond.Mode == netlink.BOND_MODE_802_3AD {
 		bond.LacpRate = netlink.BOND_LACP_RATE_FAST
 	}

--- a/host/network/network.go
+++ b/host/network/network.go
@@ -363,6 +363,10 @@ func SetupBondInterface(ifaceName string, mode netlink.BondMode) (*netlink.Bond,
 	bond := netlink.NewLinkBond(la)
 	bond.Mode = mode
 
+	if bond.Mode == netlink.BOND_MODE_802_3AD {
+		bond.LacpRate = netlink.BOND_LACP_RATE_FAST
+	}
+
 	if err := netlink.LinkAdd(bond); err != nil {
 		return nil, fmt.Errorf("%v: create: %v", bond, err)
 	}


### PR DESCRIPTION
This sets `netlink.BOND_LACP_RATE_FAST` for `802.3ad`, we also include `Miimon` set to 100 by default.

This should be tuneable at a later stage.